### PR TITLE
Enable loop unrolling for GCC

### DIFF
--- a/models/compilers/gcc_model.py
+++ b/models/compilers/gcc_model.py
@@ -10,6 +10,6 @@ class ModelImplementation(CompilerModel):
         self.cxx_name='g++'
         self.cc_name='gcc'
         self.fortran_name='gfortran'
-        self.default_compiler_flags='-O3 -ffast-math'
+        self.default_compiler_flags='-O3 -ffast-math -funroll-loops'
         self.default_dependencies=[]
 


### PR DESCRIPTION
LLVM enables loop unrolling by default at -O2 optimization level but
GCC does not enable it by default. This enables it for GCC to allow
fairer comparison.